### PR TITLE
Fix get_ulid_time in early Python 2.7 versions

### DIFF
--- a/ulid2.py
+++ b/ulid2.py
@@ -138,7 +138,7 @@ def get_ulid_time(ulid):
     ts_bytes = ulid_to_binary(ulid)[:6]
     ts_bytes = b'\0\0' + ts_bytes
     assert len(ts_bytes) == 8
-    timestamp = struct.unpack('!Q', ts_bytes)[0]
+    timestamp = struct.unpack(b'!Q', ts_bytes)[0]
     return datetime.datetime.utcfromtimestamp(timestamp / 1000.)
 
 


### PR DESCRIPTION
Adds the b'' string prefix, since unicode struct specifications weren't supported in early minor releases of Python 2.7.

In Python 2.7.6 the unit test was failing for `get_ulid_time()`. Now they pass again. I also confirmed that they continue to pass for 2.7.13 and 3.6.0.