### PR TITLE
first pass at monotonic randomness for ULIDs in the same millisecond

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Usage
 * Use `ulid2.generate_ulid_as_uuid()` to generate an ULID as an `uuid.UUID`
 * Use `ulid2.generate_ulid_as_base32()` to generate an ULID as ASCII
 
-These functions accept an optional keyword argument `timestamp` and an optional keyword argument `ensure_monotonic`.
+These functions accept optional arguments:
 
-Note that these functions are not threadsafe and may not demonstrate monotonic behavior with `ensure_motonic=True` when called from multiple threads.
+* `timestamp`: a `datetime.datetime` or integer UNIX timestamp to base the ULID on.
+* `monotonic`: boolean; whether to attempt to ensure ULIDs are monotonically increasing.  Monotonic behavior is not guaranteed when used from multiple threads.
 
 ### Parsing ULIDs
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Usage
 * Use `ulid2.generate_ulid_as_uuid()` to generate an ULID as an `uuid.UUID`
 * Use `ulid2.generate_ulid_as_base32()` to generate an ULID as ASCII
 
+These functions accept an optional keyword argument `timestamp` and an optional keyword argument `ensure_monotonic`.
+
+Note that these functions are not threadsafe and may not demonstrate monotonic behavior with `ensure_motonic=True` when called from multiple threads.
+
 ### Parsing ULIDs
 
 * Use `ulid2.get_ulid_time(ulid)` to get the time from an ULID (in any format)
@@ -49,7 +53,7 @@ from django.db import models
 from ulid2 import generate_ulid_as_uuid
 
 class MyModel(models.Model):
-	id = models.UUIDField(default=generate_ulid_as_uuid, primary_key=True)
+    id = models.UUIDField(default=generate_ulid_as_uuid, primary_key=True)
 ```
 
 and you're done!

--- a/test_ulid2.py
+++ b/test_ulid2.py
@@ -25,14 +25,16 @@ def test_ulid_time_monotonic(generator):
         '2016-07-07 14:13:10',
     ]:
         dt = datetime.datetime.strptime(time, '%Y-%m-%d %H:%M:%S')
-        ulid = generator(dt, ensure_monotonic=True)
+        ulid = generator(dt, monotonic=True)
         if last:
             assert ulid > last
         last = ulid
 
+
 def test_ulid_not_monotonic_if_flag_false():
-    some_unordered_epoch_ulids = [generate_ulid_as_base32(timestamp = 0, ensure_monotonic=False) for _ in range(100)]
+    some_unordered_epoch_ulids = [generate_ulid_as_base32(timestamp=0, monotonic=False) for _ in range(100)]
     assert sorted(some_unordered_epoch_ulids) != some_unordered_epoch_ulids
+
 
 def test_ulid_sanity():
     # https://github.com/RobThree/NUlid/blob/master/NUlid.Tests/UlidTests.cs#L14

--- a/test_ulid2.py
+++ b/test_ulid2.py
@@ -30,6 +30,9 @@ def test_ulid_time_monotonic(generator):
             assert ulid > last
         last = ulid
 
+def test_ulid_not_monotonic_if_flag_false():
+    some_unordered_epoch_ulids = [generate_ulid_as_base32(timestamp = 0, ensure_monotonic=False) for _ in range(100)]
+    assert sorted(some_unordered_epoch_ulids) != some_unordered_epoch_ulids
 
 def test_ulid_sanity():
     # https://github.com/RobThree/NUlid/blob/master/NUlid.Tests/UlidTests.cs#L14

--- a/test_ulid2.py
+++ b/test_ulid2.py
@@ -25,7 +25,7 @@ def test_ulid_time_monotonic(generator):
         '2016-07-07 14:13:10',
     ]:
         dt = datetime.datetime.strptime(time, '%Y-%m-%d %H:%M:%S')
-        ulid = generator(dt)
+        ulid = generator(dt, ensure_monotonic=True)
         if last:
             assert ulid > last
         last = ulid

--- a/test_ulid2.py
+++ b/test_ulid2.py
@@ -20,6 +20,9 @@ def test_ulid_time_monotonic(generator):
         '2013-12-01 10:10:10',
         '2016-07-07 14:12:10',
         '2016-07-07 14:13:10',
+        '2016-07-07 14:13:10',
+        '2016-07-07 14:13:10',
+        '2016-07-07 14:13:10',
     ]:
         dt = datetime.datetime.strptime(time, '%Y-%m-%d %H:%M:%S')
         ulid = generator(dt)

--- a/ulid2.py
+++ b/ulid2.py
@@ -172,7 +172,7 @@ def get_ulid_time(ulid):
 
 _last_entropy = None
 _last_timestamp = None
-def generate_binary_ulid(timestamp=None):
+def generate_binary_ulid(timestamp=None, ensure_monotonic=False):
     """
     Generate the bytes for an ULID.
 
@@ -193,7 +193,7 @@ def generate_binary_ulid(timestamp=None):
         (ts >> shift) & 0xFF for shift in (40, 32, 24, 16, 8, 0)
     )
     entropy = os.urandom(10)
-    if _last_timestamp == ts and _last_entropy is not None:
+    if ensure_monotonic and _last_timestamp == ts and _last_entropy is not None:
         while entropy < _last_entropy:
             entropy = os.urandom(10)
     _last_entropy = entropy
@@ -201,7 +201,7 @@ def generate_binary_ulid(timestamp=None):
     return ts_bytes + entropy
 
 
-def generate_ulid_as_uuid(timestamp=None):
+def generate_ulid_as_uuid(timestamp=None, ensure_monotonic=False):
     """
     Generate an ULID, but expressed as an UUID.
 
@@ -211,10 +211,10 @@ def generate_ulid_as_uuid(timestamp=None):
     :return: UUID containing ULID data.
     :rtype: uuid.UUID
     """
-    return uuid.UUID(bytes=generate_binary_ulid(timestamp))
+    return uuid.UUID(bytes=generate_binary_ulid(timestamp, ensure_monotonic))
 
 
-def generate_ulid_as_base32(timestamp=None):
+def generate_ulid_as_base32(timestamp=None, ensure_monotonic=False):
     """
     Generate an ULID, formatted as a base32 string of length 26.
 
@@ -224,7 +224,7 @@ def generate_ulid_as_base32(timestamp=None):
     :return: ASCII string
     :rtype: str
     """
-    return encode_ulid_base32(generate_binary_ulid(timestamp))
+    return encode_ulid_base32(generate_binary_ulid(timestamp, ensure_monotonic))
 
 
 def ulid_to_base32(ulid):

--- a/ulid2.py
+++ b/ulid2.py
@@ -172,13 +172,17 @@ def get_ulid_time(ulid):
 
 _last_entropy = None
 _last_timestamp = None
-def generate_binary_ulid(timestamp=None, ensure_monotonic=False):
+
+def generate_binary_ulid(timestamp=None, monotonic=False):
     """
     Generate the bytes for an ULID.
 
     :param timestamp: An optional timestamp override.
                       If `None`, the current time is used.
     :type timestamp: int|float|datetime.datetime|None
+    :param monotonic: Attempt to ensure ULIDs are monotonically increasing.
+                      Monotonic behavior is not guaranteed when used from multiple threads.
+    :type monotonic: bool
     :return: Bytestring of length 16.
     :rtype: bytes
     """
@@ -193,7 +197,7 @@ def generate_binary_ulid(timestamp=None, ensure_monotonic=False):
         (ts >> shift) & 0xFF for shift in (40, 32, 24, 16, 8, 0)
     )
     entropy = os.urandom(10)
-    if ensure_monotonic and _last_timestamp == ts and _last_entropy is not None:
+    if monotonic and _last_timestamp == ts and _last_entropy is not None:
         while entropy < _last_entropy:
             entropy = os.urandom(10)
     _last_entropy = entropy
@@ -201,30 +205,36 @@ def generate_binary_ulid(timestamp=None, ensure_monotonic=False):
     return ts_bytes + entropy
 
 
-def generate_ulid_as_uuid(timestamp=None, ensure_monotonic=False):
+def generate_ulid_as_uuid(timestamp=None, monotonic=False):
     """
     Generate an ULID, but expressed as an UUID.
 
     :param timestamp: An optional timestamp override.
                       If `None`, the current time is used.
     :type timestamp: int|float|datetime.datetime|None
+    :param monotonic: Attempt to ensure ULIDs are monotonically increasing.
+                      Monotonic behavior is not guaranteed when used from multiple threads.
+    :type monotonic: bool
     :return: UUID containing ULID data.
     :rtype: uuid.UUID
     """
-    return uuid.UUID(bytes=generate_binary_ulid(timestamp, ensure_monotonic))
+    return uuid.UUID(bytes=generate_binary_ulid(timestamp, monotonic=monotonic))
 
 
-def generate_ulid_as_base32(timestamp=None, ensure_monotonic=False):
+def generate_ulid_as_base32(timestamp=None, monotonic=False):
     """
     Generate an ULID, formatted as a base32 string of length 26.
 
     :param timestamp: An optional timestamp override.
                       If `None`, the current time is used.
     :type timestamp: int|float|datetime.datetime|None
+    :param monotonic: Attempt to ensure ULIDs are monotonically increasing.
+                      Monotonic behavior is not guaranteed when used from multiple threads.
+    :type monotonic: bool
     :return: ASCII string
     :rtype: str
     """
-    return encode_ulid_base32(generate_binary_ulid(timestamp, ensure_monotonic))
+    return encode_ulid_base32(generate_binary_ulid(timestamp, monotonic=monotonic))
 
 
 def ulid_to_base32(ulid):


### PR DESCRIPTION
I needed a ULID implementation, looked at adding monotonicicty to a few, and settled on ulid2 for my purposes. This PR isn't great (globals, eugh) but works well enough for our needs. In most cases, function calls are no slower. I could probably be a little gentler on the RNG and only request a few bytes of entropy, mask the lower bytes, and handle FFFF rollover gracefully (closer to the popular go implementation I linked at https://github.com/valohai/ulid2/issues/7), but I'm not expecting this to get called super frequently.