### PR TITLE
Performance improvements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 omit =
     setup.py
+    perftest_ulid2.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,5 @@ jobs:
           python-version: '${{ matrix.python-version }}'
       - run: pip install pytest pytest-cov
       - run: py.test -vvv --cov .
+      - run: python perftest_ulid2.py
       - uses: codecov/codecov-action@v2

--- a/perftest_ulid2.py
+++ b/perftest_ulid2.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import timeit
+
+import ulid2
+
+
+def perftest():
+    tmr = timeit.Timer(lambda: ulid2.generate_ulid_as_uuid())
+    n_iterations = 300000
+    time_taken = tmr.timeit(n_iterations)
+    return int(n_iterations / time_taken)
+
+
+def main():
+    results = []
+    for x in range(5):
+        ops_per_sec = perftest()
+        print(x + 1, " ... ", ops_per_sec)
+        results.append(ops_per_sec)
+    n_results = len(results)
+    mean = sum(results) / n_results
+    median = sorted(results)[n_results // 2]
+    print("mean ops/sec  ", mean)
+    print("median ops/sec", median)
+
+
+if __name__ == '__main__':
+    main()

--- a/ulid2.py
+++ b/ulid2.py
@@ -29,11 +29,11 @@ class InvalidULID(ValueError):
 
 
 def _to_binary(byte_list):
-    if py3:
-        return bytes(byte_list)
-    else:
-        return bytes(b''.join(chr(b) for b in byte_list))
+    return bytes(b''.join(chr(b) for b in byte_list))
 
+
+if py3:
+    _to_binary = bytes
 
 # Unrolled and optimized ULID Base32 encoding/decoding
 # implementations based on NUlid:

--- a/ulid2.py
+++ b/ulid2.py
@@ -173,6 +173,7 @@ def get_ulid_time(ulid):
 _last_entropy = None
 _last_timestamp = None
 
+
 def generate_binary_ulid(timestamp=None, monotonic=False):
     """
     Generate the bytes for an ULID.
@@ -193,9 +194,7 @@ def generate_binary_ulid(timestamp=None, monotonic=False):
         timestamp = calendar.timegm(timestamp.utctimetuple())
 
     ts = int(timestamp * 1000.0)
-    ts_bytes = _to_binary(
-        (ts >> shift) & 0xFF for shift in (40, 32, 24, 16, 8, 0)
-    )
+    ts_bytes = struct.pack('!Q', ts)[2:]
     entropy = os.urandom(10)
     if monotonic and _last_timestamp == ts and _last_entropy is not None:
         while entropy < _last_entropy:


### PR DESCRIPTION
Based on the perftest script that's being run in GitHub Actions (I know, may be affected by noisy neighbors), this PR increases the performance of generating new ULIDs rather markedly.

| platform | master | #11 | Δ |
| --- | --- | --- | --- |
| py2.7 | 68k ops/s | 83k ops/s | +21.1% |
| py3.8 | 174k ops/s | 249k ops/s | +43.3% |

After these optimizations, the hottest function is the `uuid.UUID()` constructor (which [probably could be simpler...](https://github.com/python/cpython/blob/050d1035957379d70e8601e6f5636637716a264b/Lib/uuid.py#L139)). I do have an experimental commit that would sidestep it, but I'm not sure it's safe for general consumption.