### PR TITLE
Fix monotonic ULID generation performance with high entropy values

### DIFF
--- a/test_ulid2.py
+++ b/test_ulid2.py
@@ -90,3 +90,30 @@ def test_invalid():
 
 def test_parses_largest_possible_ulid():
     assert int(get_ulid_timestamp('7ZZZZZZZZZZZZZZZZZZZZZZZZZ') * 1000) == 2 ** 48 - 1
+
+
+def test_monotonic_high_entropy_performance():
+    """Regression test: monotonic mode should not hang with high entropy values."""
+    import ulid2
+
+    # Set up worst-case scenario: last entropy near maximum
+    ulid2._last_entropy = b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe'
+    ulid2._last_timestamp = 1000
+
+    # This should complete instantly, not hang
+    result = generate_binary_ulid(timestamp=1.0, monotonic=True)  # ts=1000 ms
+
+    # Verify it's still monotonic (new entropy > old entropy)
+    assert result[6:] == b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+
+
+def test_monotonic_entropy_overflow():
+    """Test that entropy overflow raises an error."""
+    import ulid2
+
+    # Set entropy to maximum value
+    ulid2._last_entropy = b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+    ulid2._last_timestamp = 1000
+
+    with pytest.raises(OverflowError):
+        generate_binary_ulid(timestamp=1.0, monotonic=True)

--- a/ulid2/__init__.py
+++ b/ulid2/__init__.py
@@ -196,19 +196,20 @@ def generate_binary_ulid(timestamp=None, monotonic=False):
 
     ts = int(timestamp * 1000.0)
     ts_bytes = struct.pack(b'!Q', ts)[2:]
-    entropy = os.urandom(10)
     if monotonic and _last_timestamp == ts and _last_entropy is not None:
         # Increment last entropy by 1 to ensure monotonicity (O(1) vs rejection sampling)
         if py3:
             entropy_int = int.from_bytes(_last_entropy, 'big') + 1
         else:
-            entropy_int = sum(ord(b) << (8 * (9 - i)) for i, b in enumerate(_last_entropy)) + 1
+            entropy_int = int(_last_entropy.encode('hex'), 16) + 1
         if entropy_int >= (1 << 80):
             raise OverflowError("ULID entropy overflow for timestamp")
         if py3:
             entropy = entropy_int.to_bytes(10, 'big')
         else:
-            entropy = _to_binary([(entropy_int >> (8 * (9 - i))) & 0xFF for i in range(10)])
+            entropy = format(entropy_int, '020x').decode('hex')
+    else:
+        entropy = os.urandom(10)
     _last_entropy = entropy
     _last_timestamp = ts
     return ts_bytes + entropy

--- a/ulid2/__init__.py
+++ b/ulid2/__init__.py
@@ -198,8 +198,17 @@ def generate_binary_ulid(timestamp=None, monotonic=False):
     ts_bytes = struct.pack(b'!Q', ts)[2:]
     entropy = os.urandom(10)
     if monotonic and _last_timestamp == ts and _last_entropy is not None:
-        while entropy < _last_entropy:
-            entropy = os.urandom(10)
+        # Increment last entropy by 1 to ensure monotonicity (O(1) vs rejection sampling)
+        if py3:
+            entropy_int = int.from_bytes(_last_entropy, 'big') + 1
+        else:
+            entropy_int = sum(ord(b) << (8 * (9 - i)) for i, b in enumerate(_last_entropy)) + 1
+        if entropy_int >= (1 << 80):
+            raise OverflowError("ULID entropy overflow for timestamp")
+        if py3:
+            entropy = entropy_int.to_bytes(10, 'big')
+        else:
+            entropy = _to_binary([(entropy_int >> (8 * (9 - i))) & 0xFF for i in range(10)])
     _last_entropy = entropy
     _last_timestamp = ts
     return ts_bytes + entropy


### PR DESCRIPTION
Fixes #15

The previous implementation used rejection sampling to ensure monotonicity, repeatedly generating random bytes until finding a value greater than the last entropy. When the last entropy was near its maximum value (e.g., 0xffffff...), this loop could take an extremely long time or never terminate.

Replace the while loop with O(1) increment logic that adds 1 to the previous entropy value. Also add overflow detection that raises OverflowError if entropy would exceed 80 bits within the same millisecond.

